### PR TITLE
Point out where R* is listed in Rakudo Perl wiki

### DIFF
--- a/tools/star/release-guide.pod
+++ b/tools/star/release-guide.pod
@@ -210,7 +210,7 @@ Publicize the release in the appropriate places.  These include:
 
 =item * perl6-compiler@perl.org
 
-=item * http://en.wikipedia.org/wiki/Rakudo_Perl_6
+=item * http://en.wikipedia.org/wiki/Rakudo_Perl_6 (latest release date is mentioned in the main text)
 
 =item * http://en.wikipedia.org/wiki/Perl_6
 


### PR DESCRIPTION
The earlier wiki update was missed, because it's not entirely obvious where and if R* date is mentioned in the wiki. This PR fixes that.