### PR TITLE
Panda: Don't try to resolve depencies

### DIFF
--- a/tools/build/module-install.pl
+++ b/tools/build/module-install.pl
@@ -13,7 +13,7 @@ $path_sep = "\\" if ( $^O eq 'MSWin32' );
 while (<>) {
     next if /^\s*(#|$)/;
     my ($module) = /(\S+)/;
-    $exit ||= system $perl6bin, $pandabin, '--force', "install", "modules$path_sep$module";
+    $exit ||= system $perl6bin, $pandabin, '--force', '--nodeps', "install", "modules$path_sep$module";
 }
 
 exit $exit;


### PR DESCRIPTION
Without this, Panda tries to access the network to resolve the deps for
some modules (16 out of 32 at the moment), leading to them getting
skipped when Rakudo is installed without a network connection.

There's no need to resolve dependencies anyway since modules/MODULES.txt
takes care of listing modules in the correct order.

Here's what you otherwise get without a network connection:

```
==> Installing NativeHelpers::Blob from a local directory
'modules/NativeHelpers-Blob'
==> Fetching NativeHelpers::Blob
==> Building NativeHelpers::Blob
==> Testing NativeHelpers::Blob
==> Installing NativeHelpers::Blob
==> Successfully installed NativeHelpers::Blob
==> Installing DBIish from a local directory 'modules/DBIish'
Could not download module metadata: Failed to connect: network is
unreachable.
Falling back to the curl command.
curl: (7) couldn't connect to host
curl failed: The spawned process exited unsuccessfully (exit code: 7).
Falling back to the wget command.
wget failed as well: The spawned process exited unsuccessfully (exit
code: -1). Sorry, have to give up.
  in block  at
/usr/local/booking-perl/5.14.2/site/lib/auto/Fake/Perl6/share/perl6/site/sources/A1870B677797BB95A44CD4B9000A4C998866C47E
(Panda::Ecosystem) line 138
  in any  at
/usr/local/booking-perl/5.14.2/site/lib/auto/Fake/Perl6/share/perl6/site/precomp/03419F43BFFCE0AEDE2CD622AE91E8513382EF49.1469791050.00666/A1/A1870B677797BB95A44CD4B9000A4C998866C47E
line 1
  in block  at
/usr/local/booking-perl/5.14.2/site/lib/auto/Fake/Perl6/share/perl6/site/sources/A1870B677797BB95A44CD4B9000A4C998866C47E
(Panda::Ecosystem) line 134
  in any  at
/usr/local/booking-perl/5.14.2/site/lib/auto/Fake/Perl6/share/perl6/site/precomp/03419F43BFFCE0AEDE2CD622AE91E8513382EF49.1469791050.00666/A1/A1870B677797BB95A44CD4B9000A4C998866C47E
line 1
  in block  at
/usr/local/booking-perl/5.14.2/site/lib/auto/Fake/Perl6/share/perl6/site/sources/A1870B677797BB95A44CD4B9000A4C998866C47E
(Panda::Ecosystem) line 128
  in any  at
/usr/local/booking-perl/5.14.2/site/lib/auto/Fake/Perl6/share/perl6/site/precomp/03419F43BFFCE0AEDE2CD622AE91E8513382EF49.1469791050.00666/A1/A1870B677797BB95A44CD4B9000A4C998866C47E
line 1
  in method update at
/usr/local/booking-perl/5.14.2/site/lib/auto/Fake/Perl6/share/perl6/site/sources/A1870B677797BB95A44CD4B9000A4C998866C47E
(Panda::Ecosystem) line 94
  in method init-projects at
/usr/local/booking-perl/5.14.2/site/lib/auto/Fake/Perl6/share/perl6/site/sources/A1870B677797BB95A44CD4B9000A4C998866C47E
(Panda::Ecosystem) line 48
  in method get-project at
/usr/local/booking-perl/5.14.2/site/lib/auto/Fake/Perl6/share/perl6/site/sources/A1870B677797BB95A44CD4B9000A4C998866C47E
(Panda::Ecosystem) line 152
  in method get-deps at
/usr/local/booking-perl/5.14.2/site/lib/auto/Fake/Perl6/share/perl6/site/sources/582CB7486602954A4601BDCE5A0EAC54B05DA58A
(Panda) line 181
  in method resolve at
/usr/local/booking-perl/5.14.2/site/lib/auto/Fake/Perl6/share/perl6/site/sources/582CB7486602954A4601BDCE5A0EAC54B05DA58A
(Panda) line 224
  in sub MAIN at
/usr/local/booking-perl/5.14.2/site/lib/auto/Fake/Perl6/share/perl6/site/resources/E0D978079BB5081DE986D058BB8AB08252F05CC8
line 18
  in block <unit> at
/usr/local/booking-perl/5.14.2/site/lib/auto/Fake/Perl6/share/perl6/site/resources/E0D978079BB5081DE986D058BB8AB08252F05CC8
line 151
```