### PR TITLE
Remove mentions of runtime deps for zef

### DIFF
--- a/README
+++ b/README
@@ -126,8 +126,7 @@ German, Japanese, Portuguese and Spanish at the time of writing.
 
 Installing Perl 6 Modules
 -------------------------
-zef is a module installer bundled with Rakudo Star. Currently it requires
-git as a runtime dependency.
+zef is a module installer bundled with Rakudo Star.
 
 See https://github.com/ugexe/zef for zef documentation.
 


### PR DESCRIPTION
Technically you don't need git for zef to work. If you take the
default ecosystem package list and transform the git urls to the
archive url (.zip, .tar.gz) on github then git is not needed