### PR TITLE
Revert copyright year in LICENSE to original.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 		       The Artistic License 2.0
 
-	    Copyright (c) 2000-2017, The Perl Foundation.
+	    Copyright (c) 2000-2006, The Perl Foundation.
 
      Everyone is permitted to copy and distribute verbatim copies
       of this license document, but changing it is not allowed.


### PR DESCRIPTION
Per the commit message on the Rakudo LICENSE file[^1] and the source
text for the original license[^2][^3], "Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed."

[1] https://github.com/rakudo/rakudo/commit/47f5300f41cbce765471f81b52bda87bd4600be7
[2] http://www.perlfoundation.org/artistic_license_2_0
[3] https://opensource.org/licenses/Artistic-2.0