### PR TITLE
Swap panda to zef for JVM build

### DIFF
--- a/tools/build/Makefile.in
+++ b/tools/build/Makefile.in
@@ -56,8 +56,8 @@ modules-install: @backend_modules_install@
 
 modules-install-j: rakudo-install
 	@echo "== Installing modules for JVM"
-	cd modules/panda && @path@ $(DESTDIR)$(PERL6_J_INSTALL) bootstrap.pl"
-	@path@ $(PERL) tools/build/module-install.pl $(PERL6_J_INSTALL) $(DESTDIR)$(SITE_BIN_DIR)/panda-m $(MODULES)"
+	cd modules/zef && @path@ $(DESTDIR)$(PERL6_J_INSTALL) -Ilib bin/zef install ."
+	@path@ $(PERL) tools/build/module-install.pl $(PERL6_J_INSTALL) $(DESTDIR)$(SITE_BIN_DIR)/zef-m $(MODULES)"
 
 modules-install-m: rakudo-install
 	@echo "== Installing modules for MoarVM"
@@ -152,4 +152,3 @@ msi:
 	cmd /c candle star-files.wxs
 	cmd /c candle -dSTARVERSION=$(STAR_VERSION) tools/build/star-product.wxs
 	cmd /c light -b $(PREFIX_DIR) -ext WixUIExtension star-files.wixobj star-product.wixobj -o rakudo-star-$(STAR_VERSION).msi
-


### PR DESCRIPTION
Presumably fixes https://irclog.perlgeek.de/perl6/2018-03-09#i_15900928

Completely untested. Also, I'm unsure why it's `zef-m` instead of just `zef` (or why it were `panda-m`)