### PR TITLE
Fix DMG creation on newer versions of macOS

### DIFF
--- a/ports/darwin_dmg/fileicon
+++ b/ports/darwin_dmg/fileicon
@@ -1,0 +1,33 @@
+#! /usr/bin/swift
+
+import Darwin
+import Cocoa
+
+func die(_ msg: String) {
+    fputs("\(msg)\n", stderr)
+    exit(1)
+}
+
+let name = CommandLine.arguments[0]
+
+/*
+ * We don't do anything with the 'set' at the moment; it's just there to
+ * reserve a space for a subcommand to allow for future expansion without
+ * changing the interface.
+ */
+if CommandLine.argc == 4 && CommandLine.arguments[1] == "set" {
+    let target_file = CommandLine.arguments[2]
+    let icon_file_name = CommandLine.arguments[3]
+
+    if let icon = Cocoa.NSImage.init(contentsOfFile: icon_file_name) {
+        if !NSWorkspace.shared.setIcon(icon, forFile: target_file) {
+            die("Failed to set icon for '\(target_file)'")
+        }
+    }
+    else {
+        die("Failed to read icon file '\(icon_file_name)'")
+    }
+}
+else {
+    die("Usage: \(name) set FILE ICON_FILE")
+}


### PR DESCRIPTION
The only problem with building on more recent versions (this was tested on 10.14) seems to be the deprecation of utilities used for setting the icon on the perl6 executable.

Evidently this is only possible now via Cocoa APIs.  The usual solution seems to be using the system Python, which comes with a Cocoa module.