### PR TITLE
Add Inline::Perl5 module

### DIFF
--- a/etc/modules.txt
+++ b/etc/modules.txt
@@ -40,6 +40,11 @@ NativeHelpers-Blob   git  https://github.com/salortiz/NativeHelpers-Blob.git    
 NativeLibs           git  https://github.com/salortiz/NativeLibs.git             master
 DBIish               git  https://github.com/raku-community-modules/DBIish.git   master
 
+# Inline::*
+System-Query                       git  https://github.com/tony-o/p6-warthog.git                       master
+Distribution-Builder-MakeFromJSON  git https://github.com/niner/Distribution-Builder-MakeFromJSON.git  master
+Inline-Perl5                       git  https://github.com/niner/Inline-Perl5.git                      master
+
 # Taken from the previous iteration of Rakudo Star
 URI                      git  https://github.com/raku-community-modules/uri.git                master
 JSON-Name                git  https://github.com/jonathanstowe/JSON-Name.git                   master


### PR DESCRIPTION
This module currently fails with the following error:

```
[2021-01-07T00:19:54] Installing Inline-Perl5                                                                                           
Failed to open file /home/tyil/projects/personal/rakudo-star/src/rakudo-star-modules/Inline-Perl5/resources/libraries/libp5helper.so: No such file or directory
  in sub MAIN at /home/tyil/projects/personal/rakudo-star/lib/install-module.raku line 27                                               
  in block <unit> at /home/tyil/projects/personal/rakudo-star/lib/install-module.raku line 1
```

Fixes #154 