### PR TITLE
coming GitHub Actions integration

### DIFF
--- a/etc/fetch_core.txt
+++ b/etc/fetch_core.txt
@@ -1,12 +1,12 @@
 # These are the version numbers of the core components of Rakudo Star. Change
 # these if you want to create a distribution containing different core
 # component versions.
-moarvm_version=2021.04
-nqp_version=2021.04
-rakudo_version=2021.04
+moarvm_version=2021.10
+nqp_version=2021.10
+rakudo_version=2021.10
 
 # These are the URLs to fetch the sources from. You can use %s in the URLs as a
 # placeholder for the version number, specified above.
-moarvm_url=https://www.moarvm.org/releases/MoarVM-%s.tar.gz
-nqp_url=https://github.com/perl6/nqp/releases/download/%s/nqp-%s.tar.gz
+moarvm_url=https://github.com/MoarVM/MoarVM/releases/download/%s/MoarVM-%s.tar.gz
+nqp_url=https://github.com/Raku/nqp/releases/download/%s/nqp-%s.tar.gz
 rakudo_url=https://github.com/rakudo/rakudo/releases/download/%s/rakudo-%s.tar.gz

--- a/lib/main.bash
+++ b/lib/main.bash
@@ -78,7 +78,7 @@ Usage:
 	rstar build-docker [-T tag] [-b backend] [-d description] [-l] [-n name] [-t version] <base>
 	rstar clean [-s]
 	rstar dist [version]
-	rstar fetch
+	rstar fetch [-l]
 	rstar install [-b backend] [-p prefix] [core] [modules]
 	rstar sysinfo
 	rstar test [-p prefix] [spectest] [modules]
@@ -94,9 +94,15 @@ Actions:
 	clean         Clean up the repository. If -s is given, the src
 	              directory will also be removed.
 	dist          Create a distributable tarball of this repository. If no
-	              version identifier is specified, it will use the current
-	              year and month in "yyyy.mm" notation.
-	fetch         Fetch all required sources.
+	              version identifier is specified, it will assume it should
+	              build ontop of the latest RAKUDO release and therefore
+	              check "https://github.com/rakudo/rakudo/releases/latest"
+	              for something like i.e. "2020.08" or "2020.08.1".
+	              If the "RAKUDO latest" doesn't match, it will use the
+	              current year and month in "yyyy.mm" notation.
+	fetch         Fetch all required sources. If -l is given, the GitHub
+	              "latest" releases from all components will be fetched.
+	              If GitHub latest doesn't fit, fallback to "fetch_core.txt"
 	install       Install Raku on this system. By default, MoarVM will be
 	              used as the only backend, and the Rakudo Star directory
 	              will be used as prefix. If neither core nor modules are


### PR DESCRIPTION
Introducing "rstar fetch [-l]" which fetches "Rakudo latest" from https://github.com/rakudo/rakudo/releases/latest
This is a requirement for the coming GitHub Actions integration