### PR TITLE
Run zef build for modules that have a Build.pm6

### DIFF
--- a/lib/actions/install.bash
+++ b/lib/actions/install.bash
@@ -232,6 +232,11 @@ build_prepare() {
 }
 
 install_raku_module() {
+	if [[ -f "$1/Build.pm6" ]]
+	then
+		"$RSTAR_PREFIX/bin/raku" "$RSTAR_PREFIX/share/perl6/vendor/bin/zef" build "$1"
+	fi
+
 	"$RSTAR_PREFIX/bin/raku" "$BASEDIR/lib/install-module.raku" "$1"
 }
 


### PR DESCRIPTION
Module install is currently not running build actions, which affects rakudoc and openssl.

This will run ref build for any modules that have a `Build.pm6` file.