### PR TITLE
Use C.UTF-8 on Arch Linux

### DIFF
--- a/lib/actions/install.bash
+++ b/lib/actions/install.bash
@@ -46,7 +46,6 @@ action() {
 	case ${RSTAR_PLATFORM["key"]} in
                 darwin)           LC_ALL=en_US.UTF-8 ;;
 		dragonfly)        LC_ALL=C           ;;
-		linux-arch_linux) LC_ALL=en_US.UTF-8 ;;
 		*)                LC_ALL=C.UTF-8     ;;
 	esac
 


### PR DESCRIPTION
The [glibc](https://archlinux.org/packages/core/x86_64/glibc/) package ships with `C.UTF-8` by default now.
See https://monthly-reports.archlinux.page/2022/06/#glibc.