### PR TITLE
src/Perl6/Compiler.nqp: Show "Star" in the version output

### DIFF
--- a/lib/actions/fetch.bash
+++ b/lib/actions/fetch.bash
@@ -80,6 +80,7 @@ download_core() {
 
 	tarball="$(fetch_http "$source")" \
 		&& tar xzf "$tarball" -C "$destination" \
+        && ( if [[ "$1" =~ "rakudo" ]]; then sed '/"Welcome to "/,+2 { s/" v"/" Star v"/g; }' $destination/rakudo-$VERSION/src/Perl6/Compiler.nqp > ./Compiler.nqp && mv ./Compiler.nqp $destination/rakudo-$VERSION/src/Perl6/Compiler.nqp; fi ) \
 		&& return
 
 	crit "Failed to download $destination"

--- a/lib/actions/fetch.bash
+++ b/lib/actions/fetch.bash
@@ -80,7 +80,7 @@ download_core() {
 
 	tarball="$(fetch_http "$source")" \
 		&& tar xzf "$tarball" -C "$destination" \
-        && ( if [[ "$1" =~ "rakudo" ]]; then sed '/"Welcome to "/,+2 { s/" v"/" Star v"/g; }' $destination/rakudo-$VERSION/src/Perl6/Compiler.nqp > ./Compiler.nqp && mv ./Compiler.nqp $destination/rakudo-$VERSION/src/Perl6/Compiler.nqp; fi ) \
+        && ( if [[ "$1" =~ "rakudo" ]]; then  notice "Setting Rakudo Star v$RAKUDO_VER in src/Perl6/Compiler.nqp"; sed '/"Welcome to "/,+2 { s/" v"/" Star v"/g; }' $destination/rakudo-$VERSION/src/Perl6/Compiler.nqp > ./Compiler.nqp && mv ./Compiler.nqp $destination/rakudo-$VERSION/src/Perl6/Compiler.nqp; fi ) \
 		&& return
 
 	crit "Failed to download $destination"

--- a/tools/build/binary-release/Windows/build-with-choco.ps1
+++ b/tools/build/binary-release/Windows/build-with-choco.ps1
@@ -92,6 +92,10 @@ cd rakudo-$RAKUDO_VER
 
 $PrefixPath = $env:Temp + "\rakudo-star-$RAKUDO_VER"
 Write-Host "   INFO - `"`$PrefixPath`" set to $PrefixPath"
+
+Write-Host "   INFO - Setting `"Rakudo Star v$RAKUDO_VER`" in `".\src\Perl6\Compiler.nqp`""
+(Get-Content -Raw .\src\Perl6\Compiler.nqp) -creplace '\s+"Welcome to "\r?\n\s+ ~ \$rakudo\r?\n\s+ ~ " ', '$0Star ' | Set-Content .\src\Perl6\Compiler.nqp
+
 Write-Host "   INFO - Building NQP, Moar and Rakudo $RAKUDO_VER"
 # "Configure.pl" help -> https://github.com/rakudo/rakudo/blob/master/Configure.pl#L140-L210
 perl Configure.pl --backends=moar --gen-moar --gen-nqp --moar-option='--toolchain=msvc' --no-silent-build --relocatable --prefix=$PrefixPath --out=RAKUDO-${RAKUDO_VER}_build.log


### PR DESCRIPTION
Add "Star" in the various raku version outputs...

So, instead now:
- `Welcome to Rakudo v2023.12`
something like:
- `Welcome to Rakudo Star v2023.12`
will be shown in `raku -v` (and similar commands)