### PR TITLE
Revert "Bump actions/download-artifact from 3 to 4.1.7 in /.github/workflows"

### DIFF
--- a/.github/workflows/build_rakudo-star.yml
+++ b/.github/workflows/build_rakudo-star.yml
@@ -82,7 +82,7 @@ jobs:
     needs: [build_Rakudo-Star_Windows_MSI_package, build_Rakudo-Star_Linux_source]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/download-artifact@v4.1.7
+    - uses: actions/download-artifact@v3
       with:
         path: Rakudo-Star_artifacts
     - name: List my stuff


### PR DESCRIPTION
Reverts rakudo/star#203