### PR TITLE
MSI & LICENSE: Add InstallScope And Update Copyright Year

### DIFF
--- a/tools/build/binary-release/Windows/License.rtf
+++ b/tools/build/binary-release/Windows/License.rtf
@@ -2,7 +2,7 @@
 {\*\generator Riched20 10.0.18362}\viewkind4\uc1 
 \pard\sa200\sl276\slmult1\qc\b\f0\fs22\lang9 Artistic License 2.0\b0\par
 
-\pard\sa200\sl276\slmult1 Copyright (c) 2000-2006, The Perl Foundation.\par
+\pard\sa200\sl276\slmult1 Copyright (c) 2000-2026, The Perl Foundation.\par
 Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.\par
 \b Preamble\b0\par
 This license establishes the terms under which a given free software Package may be copied, modified, distributed, and/or redistributed. The intent is that the Copyright Holder maintains some artistic control over the development of that Package while still keeping the Package available as open source and free software.\par

--- a/tools/build/binary-release/Windows/star.wxs
+++ b/tools/build/binary-release/Windows/star.wxs
@@ -9,10 +9,11 @@
         <Package Compressed="yes"
 				InstallerVersion="301"
 				Platform="x64"
+				InstallScope="perMachine"
 				Manufacturer="The Raku Community"
 				Description="Installs Rakudo Star $(var.STARVERSION)"
 				Keywords="Raku, Rakudo"
-				Comments="(c) 2021 The Raku Community"/>
+				Comments="(c) 2026 The Raku Community"/>
 		<Media Id="1" Cabinet="product.cab" EmbedCab="yes" />
 		
 		<!-- Installation Path as given by user in the prompt -->


### PR DESCRIPTION
MSI & LICENSE: Add InstallScope And Update Copyright Year

Add InstallScope="perMachine" to the Package element in [star.wxs](https://github.com/rakudo/star/blob/master/tools%2Fbuild%2Fbinary-release%2FWindows%2Fstar.wxs) and update the copyright year in [License.rtf](https://github.com/rakudo/star/blob/master/tools%2Fbuild%2Fbinary-release%2FWindows%2FLicense.rtf) copyright line from 2000-2006 to 2000-2026.

This ensures consistent installation scope and prevents ambiguity in per-user vs per-machine installs. It also refreshes metadata to reflect the current year.

- Explicitly set InstallScope for MSI installer
- Update copyright year
- Improve metadata consistency