### PR TITLE
Add `-NoTest`/`-T` flag and `RSTAR_NO_TEST` env var to skip module tests for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ Both tools compile Rakudo and then add some selected modules!
 
 ### 1. _RSTAR_ tool
 
+* `bash` based tool, should work on any **Linux OS** (_should also build Rakudo-Star on macOS_!?).
+  - The `rstar` (bash) tool downloads all requirements, like MoarVM, NQP, Rakudo and some Rakudo modules.
+  - It then compiles everything into a local Rakudo installation and add's the modules via `zef`.
+* More information can be found in the [related Wiki page](https://github.com/rakudo/star/wiki/01_Rakudo-Star---Linux-package)
+
+As the `rstar` utility is written in `bash`, all additional features should also be
+based on `bash`. Using other utilities is accepted, but efforts should be made to
+avoid introducing new utilities.
+
+Furthermore, all code should be linted against [`shellcheck`](https://www.shellcheck.net/) and not produce any warnings.
+
 #### Usage
 
 ```
@@ -65,24 +76,45 @@ RSTAR_NO_TEST=1 rstar install modules
 > Note: When a module fails and is retried with `--force-test`, tests are
 > always run regardless of this option.
 
----
-
-* `bash` based tool, should work on any **Linux OS** (_should also build Rakudo-Star on macOS_!?).
-  - The `rstar` (bash) tool downloads all requirements, like MoarVM, NQP, Rakudo and some Rakudo modules.
-  - It then compiles everything into a local Rakudo installation and add's the modules via `zef`.
-* More information can be found in the [related Wiki page](https://github.com/rakudo/star/wiki/01_Rakudo-Star---Linux-package)
-
-As the `rstar` utility is written in `bash`, all additional features should also be
-based on `bash`. Using other utilities is accepted, but efforts should be made to
-avoid introducing new utilities.
-
-Furthermore, all code should be linted against [`shellcheck`](https://www.shellcheck.net/) and not produce any warnings.
-
 ### 2. _BUILD-WITH-CHOCO.PS1_ tool
 
 * A [Powershell script](https://github.com/rakudo/star/blob/master/tools/build/binary-release/Windows/build-with-choco.ps1), which internally uses `chocolatey` to create a **Windows MSI** package.
     - The created MSI package can be used to install Rakudo-Star (Rakudo with some additional modules) on any Windows device.
-* *More information to be added* in the [wiki](https://github.com/rakudo/star/wiki)
+* More information can be found in the [wiki](https://github.com/rakudo/star/wiki)
+
+#### Usage
+
+```powershell
+.\build-with-choco.ps1 [[-RAKUDO_VER] <version>] [-sign] [-keep] [-NoTest]
+```
+
+**Parameters:**
+
+| Parameter | Description |
+|-----------|-------------|
+| `-RAKUDO_VER <version>` | The Rakudo release to build, e.g. `2026.04`. If omitted, the latest release is fetched automatically from GitHub. |
+| `-sign` | Sign the resulting `.msi` and checksum file with GPG. |
+| `-keep` | Keep the intermediate build artefacts after a successful build. |
+| `-NoTest` / `-T` | Skip module tests during `zef` installs (`--/test`). |
+
+**Skipping module tests:**
+
+By default, `zef` runs all tests when installing bundled modules. Pass `-NoTest`
+(or its alias `-T`) to disable this, which can significantly speed up the build:
+
+```powershell
+.\build-with-choco.ps1 -NoTest
+```
+
+You can also set the environment variable `RSTAR_NO_TEST` to any non-empty
+value to achieve the same effect without modifying the command:
+
+```powershell
+$env:RSTAR_NO_TEST = 1
+.\build-with-choco.ps1
+```
+
+---
 
 ### 3. Community Modules
 

--- a/tools/build/binary-release/Windows/build-with-choco.ps1
+++ b/tools/build/binary-release/Windows/build-with-choco.ps1
@@ -1,4 +1,29 @@
-param ([string]$RAKUDO_VER, [switch]$sign, [switch]$keep)
+<#
+.SYNOPSIS
+    Build a Rakudo Star Windows installer
+
+.PARAMETER RAKUDO_VER
+    The Rakudo release to build, e.g. "2026.04".
+    If omitted, the latest release is fetched automatically from GitHub.
+
+.PARAMETER sign
+    Sign the resulting .msi and checksum file with GPG.
+
+.PARAMETER keep
+    Keep the intermediate build artefacts after a successful build.
+
+.PARAMETER NoTest
+    Skip module tests during zef installs (equivalent to setting the
+    RSTAR_NO_TEST environment variable).  Passes --/test instead of
+    --force-test to every "zef install" invocation.  Alias: -T
+#>
+param (
+    [string] $RAKUDO_VER,
+    [switch] $sign,
+    [switch] $keep,
+    [Alias("T")]
+    [switch] $NoTest
+)
 
 # inspired by https://github.com/hankache/rakudo-star-win/blob/master/build.ps1
 # expected $RAKUDO_VER is something like "2021.03"
@@ -10,6 +35,9 @@ param ([string]$RAKUDO_VER, [switch]$sign, [switch]$keep)
 # https://david.gardiner.net.au/2020/04/azure-pipelines-powershell-7-errors.html
 # https://github.com/microsoft/azure-pipelines-tasks/issues/12799
 $ErrorView = 'NormalView'
+
+# If RSTAR_NO_TEST is set or -T is passed, skip tests during zef installs
+IF ( ($env:RSTAR_NO_TEST) -OR ($NoTest) ) { $testFlag = "--/test" } ELSE { $testFlag = "--force-test" }
 
 # Set the "RAKUDO_FLAVOR" environment variable to "Star", see
 #   https://github.com/rakudo/rakudo/commit/6e55b118edcbf60aa0aff875fbcdc21706a782a0
@@ -38,7 +66,7 @@ IF ( -NOT ((Get-Command "cl.exe" -ErrorAction SilentlyContinue).Path) ) {
   Write-Host "          https://github.com/rakudo/rakudo/commit/d01d4b26641bec2a62b43007b476f668982b9ab6#diff-a3c0a8904b9af2275c7ef3d4616ad9c3481898d3cc0e4698133948520b2df2ed"
   Write-Host "          https://github.com/Raku/nqp-configure/blob/e068508a94d643c1174bcd29e333dd659df502c5/lib/NQP/Config.pm#L252"
   Write-Host "          https://github.com/Raku/nqp-configure/commit/1a9539a8f60343a231cccf8aeb7c9e3c48d2c2ee"
-  
+
   IF ( -NOT ((Get-Command "Launch-VsDevShell.ps1" -ErrorAction SilentlyContinue).Path) ) {
     Write-Host "  ERROR - Couldn't neither find `"cl.exe`" nor `"Launch-VsDevShell.ps1`""
     Write-Host "  ERROR - Make sure `"Microsoft Visual C++ 2019`" or newer is installed and try again"
@@ -123,7 +151,7 @@ CheckLastExitCode
 
 cd zef
 Write-Host "   INFO - Installing ZEF"
-& $PrefixPath\bin\raku.exe -I. bin\zef install . --debug --force-test --install-to=$PrefixPath\share\perl6\site\
+& $PrefixPath\bin\raku.exe -I. bin\zef install . --debug $testFlag --install-to=$PrefixPath\share\perl6\site\
 CheckLastExitCode
 
 # Add the required rakudo folders to PATH in order for some modules to test correctly (File::Which)
@@ -142,16 +170,16 @@ Select-String -Path rakudo-star-modules.txt -Pattern " http "," git " -SimpleMat
   $moduleName = $moduleName.replace("-","::")
   Write-Host "   INFO - ZEF: installing $moduleName, $moduleUrl"
   IF ( $moduleName -ne "zef" ) {
-    
+
     IF ( ("$moduleName" -match "^Terminal") -AND ( -NOT ($readLineDLL) ) ) {
         Write-Host "   INFO - Copy required `"readline.dll`" from `"https://raw.githubusercontent.com/AntonOks/rakudo_star_module_libs/main/3rdparty/win32/readline/readline.dll`""
         & curl.exe -s https://raw.githubusercontent.com/AntonOks/rakudo_star_module_libs/main/3rdparty/win32/readline/readline.dll --output $PrefixPath\bin\readline.dll
         CheckLastExitCode
         $readLineDLL = $True
     }
-    
-    IF ( [string]( & zef install $moduleName --debug --force-test --install-to=$PrefixPath\share\perl6\site\) -match 'No candidates found matching identity' ) {
-        & zef install $moduleUrl --debug --force-test --install-to=$PrefixPath\share\perl6\site\
+
+    IF ( [string]( & zef install $moduleName --debug $testFlag --install-to=$PrefixPath\share\perl6\site\) -match 'No candidates found matching identity' ) {
+        & zef install $moduleUrl --debug $testFlag --install-to=$PrefixPath\share\perl6\site\
     }
   }
 }


### PR DESCRIPTION
According to @AntonOks 's advice: https://github.com/rakudo/star/pull/222#issuecomment-4416037241

Related discussion: #221